### PR TITLE
Update bootstrapping data and 

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,9 +65,9 @@ func main() {
 	adminRouter.Handle("/recipe/{recipe_id}/label/{label_id}", wrappedHandler(untagRecipe)).Methods("DELETE")
 
 	// Label routes
-	adminRouter.Handle("/label/{label_name}", wrappedHandler(addLabel)).Methods("PUT")
 	adminRouter.Handle("/label/id/{label_id}", wrappedHandler(editLabel)).Methods("PUT")
 	adminRouter.Handle("/label/id/{label_id}", wrappedHandler(removeLabel)).Methods("DELETE")
+	adminRouter.Handle("/label/{label_name}", wrappedHandler(addLabel)).Methods("PUT")
 
 	// Note routes
 	adminRouter.Handle("/recipe/{id}/note/", wrappedHandler(createNoteOnRecipe)).Methods("POST")


### PR DESCRIPTION
Moved specific /label/id/{label_id} routes before the general /label/{label_name} route. This prevents the router from incorrectly matching requests like PUT /label/id/8 to the addLabel handler instead of editLabel.

In gorilla/mux, routes are evaluated in order, so more specific patterns must be registered before more general ones.